### PR TITLE
Improve compile_results.sh performance

### DIFF
--- a/compile_results.sh
+++ b/compile_results.sh
@@ -77,8 +77,8 @@ for FILE in $(ls "$DIR") ; do
 	MODEL=$(echo $FILE | sed -E "s/([^\.]*).*/\1/")
 	Q=$(echo $FILE | sed -E "s/[^\.]*\.([0-9]*).*/\1/")
 
-	# Get stdout of model and replace new lines such that regex will work
-	RES=$(cat "$DIR/$FILE" | tr '\n' '\r')
+	# Get stdout of model, filter out transition and place-bound statistics, and replace new lines such that regex will work
+	RES=$(cat "$DIR/$FILE" | grep -v "^<" | tr '\n' '\r')
 
 	# Time and memory is appended to the file
 	TIME=$(echo $RES | sed -E "s/.*@@@(.*),.*@@@.*/\1/")

--- a/ex.out
+++ b/ex.out
@@ -1,45 +1,73 @@
-Parameters: -x 2 MCC2021/ASLink-PT-01a/model.pnml MCC2021/ASLink-PT-01a/ReachabilityCardinality.xml
+Parameters: -r 3 0,1,2,3,4,5,6,7,8,9,10 -x 1 test_models/arithmetic-test003/model.pnml test_models/arithmetic-test003/query.xml
 
-Search=OverApprox,Trace=DISABLED,State_Space_Exploration=DISABLED,Structural_Reduction=AGGRESSIVE,Struct_Red_Timout=60,Stubborn_Reduction=ENABLED,Query_Simplication=ENABLED,QSTimeout=30,Siphon_Trap=DISABLED,LPSolve_Timeout=10
+Search=OverApprox,Trace=DISABLED,State_Space_Exploration=DISABLED,Structural_Reduction=KBOUND_PRESERVING,Struct_Red_Timout=60,Stubborn_Reduction=ENABLED,Query_Simplication=ENABLED,QSTimeout=30,Siphon_Trap=DISABLED,LPSolve_Timeout=10
 Finished parsing model
 RWSTATS LEGEND:EG p-> !EF !p,AG p-> !AF !p,!EX p -> AX p,EX false -> false,EX true -> !deadlock,!AX p -> EX p,AX false -> deadlock,AX true -> true,EF !deadlock -> !deadlock,EF EF p -> EF p,EF AF p -> AF p,EF E p U q -> EF q,EF A p U q -> EF q,EF .. or .. -> EF .. or EF ..,AF !deadlock -> !deadlock,AF AF p -> AF p,AF EF p -> EF p,AF .. or EF p -> EF p or AF ..,AF A p U q -> AF q,A p U !deadlock -> !deadlock,A deadlock U q -> q,A !deadlock U q -> AF q,A p U AF q -> AF q,A p U EF q -> EF q,A p U .. or EF q -> EF q or A p U ..,E p U !deadlock -> !deadlock,E deadlock U q -> q,E !deadlock U q -> EF q,E p U EF q -> EF q,E p U .. or EF q -> EF q or E p U ..,!! p -> p,F F p -> F p,F p U q -> F q,F p or q -> F p or F q,p U F q -> F q,
 
-Query before reduction: AG (p244 <= p110)
-RWSTATS PRE:0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-RWSTATS POST:0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+Query before reduction: EF ((0 + P0 + P1 + P2 + P3 + P4 + P5) == 0)
+RWSTATS PRE:0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+RWSTATS POST:0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
 
-Query after reduction: (not EF (p110 < p244))
-Query reduction finished after 3.42072 seconds.
-Query size reduced from 4 to 5 nodes ( -25 percent reduction).
+Query after reduction: EF ((0 + P0 + P1 + P2 + P3 + P4 + P5) <= 0)
+Query reduction finished after 0.000887 seconds.
+Query size reduced from 10 to 10 nodes ( 0 percent reduction).
 
-Size of net before structural reductions: 431 places, 735 transitions
-Size of net after structural reductions: 344 places, 659 transitions
-Structural reduction finished after 68.5942 seconds
+SPEND 0 ON A
+REM 0 0
+SPEND 0 ON B
+REM 0 0
+SPEND 0 ON C
+REM 0 0
+SPEND 0 ON D
+REM 0 0
+SPEND 0 ON E
+REM 0 0
+SPEND 0 ON F
+REM 0 0
+SPEND 0 ON G
+REM 0 0
+SPEND 0 ON H
+REM 0 0
+SPEND 0 ON I
+REM 0 0
+SPEND 0 ON J
+REM 0 0
+SPEND 0 ON K
+REM 0 0
+Size of net before structural reductions: 13 places, 13 transitions
+Size of net after structural reductions: 13 places, 13 transitions
+Structural reduction finished after 0.031372 seconds
 
 Net reduction is enabled.
-Removed transitions: 76
-Removed places: 87
-Applications of rule A: 1
-Applications of rule B: 71
-Applications of rule C: 18
+Removed transitions: 0
+Removed places: 0
+Applications of rule A: 0
+Applications of rule B: 0
+Applications of rule C: 0
 Applications of rule D: 0
 Applications of rule E: 0
-Applications of rule F: 1
+Applications of rule F: 0
 Applications of rule G: 0
 Applications of rule H: 0
 Applications of rule I: 0
 Applications of rule J: 0
 Applications of rule K: 0
-Applications of rule L: 8
+Applications of rule L: 0
 
-FORMULA ASLink-PT-01a-ReachabilityCardinality-01 FALSE TECHNIQUES COLLATERAL_PROCESSING STRUCTURAL_REDUCTION QUERY_REDUCTION SAT_SMT EXPLICIT STATE_COMPRESSION STUBBORN_SETS
+FORMULA arithmetic-test003.TRUE-1 TRUE TECHNIQUES COLLATERAL_PROCESSING STRUCTURAL_REDUCTION QUERY_REDUCTION SAT_SMT EXPLICIT STATE_COMPRESSION STUBBORN_SETS
 Query index 0 was solved
 
-Query is NOT satisfied.
+Query is satisfied.
 
 STATS:
-        discovered states: 53
-        explored states:   53
-        expanded states:   27
-        max tokens:        19
+        discovered states: 19
+        explored states:   19
+        expanded states:   4
+        max tokens:        10
+
+TRANSITION STATISTICS
+<T0:1><T4:1><T3:0><T1:0><T11:4><T2:0><T12:3><T6:2><T13:2><T7:2><T8:1><T9:1><T10:1>
+
+PLACE-BOUND STATISTICS
+<P0;1><P1;1><P2;1><P3;2><P4;2><P5;2><P6;1><P7;1><P8;1><P9;1><P10;1><P11;1><P12;1>
 @@@0.23,2312@@@


### PR DESCRIPTION
Filtering out transition and place-bound statistics improves performance by a lot, since those lines where typically many thousand characters long. But we don't need them.