### PR TITLE
Add extract_query_type.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,5 @@ __pycache__
 graphs/
 sizes/*
 !sizes/query.xml
+RC_types/*
 saved/everything/

--- a/extract_query_types.sh
+++ b/extract_query_types.sh
@@ -14,7 +14,7 @@ if [ -z "$TEST_FOLDER" ] ; then
 	TEST_FOLDER="MCC2021"
 fi
 
-OUT="RC_types.csv"
+OUT="RC_types/RC_types.csv"
 rm -f $OUT
 echo "model name,query index,type" >> $OUT
 

--- a/extract_query_types.sh
+++ b/extract_query_types.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+#SBATCH --time=3:00:00
+#SBATCH --mail-type=FAIL
+#SBATCH --partition=rome
+#SBATCH --mem=15G
+
+# Args: [test-folder]
+# Finds type (EF or AG) of reachability cardinality formulas in the given test folder and stores it as `RCtypes.csv`
+
+TEST_FOLDER=$1
+
+if [ -z "$TEST_FOLDER" ] ; then
+	echo "No TEST_FOLDER given, using MCC2021"
+	TEST_FOLDER="MCC2021"
+fi
+
+OUT="RC_types.csv"
+rm -f $OUT
+echo "model name,query index,type" >> $OUT
+
+for MODEL in $(ls $TEST_FOLDER) ; do
+
+	# Extract propeties. It's every 5th line offset by 4
+	PROPS=$(cat "$TEST_FOLDER/$MODEL/ReachabilityCardinality.txt" | awk 'NR % 5 == 4')
+	
+	# Read each line in variable PROPS
+	Q=1
+	while IFS= read -r PROP; do
+		
+		# Extract and output type
+		TYPE=$([[ -n $(echo $PROP | awk '/^ *E F/') ]] && echo "EF" || echo "AG")
+		echo "$MODEL,$Q,$TYPE" > $OUT
+
+		((Q=Q+1))
+	done <<< "$PROPS"
+done


### PR DESCRIPTION
The `extract_query_type.sh` extracts whether the ReachabilityCardinality queries are EF or AG formulas. When combined with verification results, this allows us to differ between "positive" and "negative" results. In other words, whether verifypn terminated early.