### PR TITLE
Hopefully last graph fixes

### DIFF
--- a/graph_utility/answer_simplification_bars.py
+++ b/graph_utility/answer_simplification_bars.py
@@ -3,6 +3,7 @@ import copy
 import matplotlib.pyplot as plt
 import pandas as pd
 import seaborn as sns
+import utility
 
 
 def plot(data_list, test_names, graph_dir):
@@ -77,6 +78,7 @@ def plot(data_list, test_names, graph_dir):
         combined = combined.append(temp)
 
     # Plot the plot
+    combined.rename(utility.rename_test_name_for_paper_presentation(test_names), axis='columns', inplace=True)
     sns.set_theme(style="darkgrid", palette="pastel")
     plot = combined.plot(kind='barh', width=0.75, linewidth=2, figsize=(10, 10), stacked=True)
 

--- a/graph_utility/lines.py
+++ b/graph_utility/lines.py
@@ -23,7 +23,7 @@ def plot(data_list, test_names, graph_dir, metric, keep_largest_percent):
 
     base_width = 3
     other_width = 1.5
-    base_name = 'fixedbase'
+    base_name = 'base'
     cutoff_time = {'total time': 5, 'verification time': 5, 'reduce time': 5}
 
     time_metrics = ['total time', 'verification time', 'reduce time']
@@ -86,10 +86,10 @@ def plot(data_list, test_names, graph_dir, metric, keep_largest_percent):
             continue
         combined_df = pd.concat([combined_df, metric_data], axis=1)
 
+    combined_df.rename(utility.rename_test_name_for_paper_presentation(test_names), axis='columns', inplace=True)
+
     sns.set_theme(style="darkgrid")
     custom_palette = {}
-
-    # dashes = []
     for column_index, column in enumerate(combined_df.columns):
         custom_palette[column] = utility.color((column_index + 1) / len(combined_df.columns))
 
@@ -102,14 +102,16 @@ def plot(data_list, test_names, graph_dir, metric, keep_largest_percent):
     elif metric == 'reduced size':
         unit = 'ratio given by post size/pre size'
 
+
     my_dashes = linestyles[0:len(combined_df.columns) - 1]
-    columns_without_base = [column for column in combined_df.columns if column != 'fixedbase']
+
+    columns_without_base = [column for column in combined_df.columns if column != base_name]
     # sns.set(rc={'figure.figsize': (11.7, 8.27)})
     if not (len(combined_df) == 0 or len(combined_df.columns) == 0):
         # Plot the plot
         #
         if base_name in test_names:
-            sns.lineplot(data=combined_df[base_name], palette=custom_palette, linewidth=base_width, label='base')
+            sns.lineplot(data=combined_df[base_name], palette=custom_palette, linewidth=base_width)
             plot = sns.lineplot(data=combined_df[columns_without_base], palette=custom_palette, linewidth=other_width,
                                 dashes=my_dashes)
         else:

--- a/graph_utility/lines.py
+++ b/graph_utility/lines.py
@@ -116,12 +116,12 @@ def plot(data_list, test_names, graph_dir, metric, keep_largest_percent):
             plot = sns.lineplot(data=combined_df, palette=custom_palette)
         plot.set(
             ylabel=f'{unit}',
-            xlabel='test instances')
+            xlabel='queries')
 
-        if metric in time_metrics:
-            plot.set(title=f'{metric} per test instance sorted, above {cutoff_time[metric]} seconds')
-        else:
-            plot.set(title=f'{metric} per test instance sorted, using {keep_largest_percent * 100}% largest tests')
+        #if metric in time_metrics:
+        #    plot.set(title=f'{metric} per test instance sorted, above {cutoff_time[metric]} seconds')
+        #else:
+        #    plot.set(title=f'{metric} per test instance sorted, using {keep_largest_percent * 100}% largest tests')
 
         if metric == "reduced size":
             plot.set(yscale="linear")

--- a/graph_utility/rule_usage.py
+++ b/graph_utility/rule_usage.py
@@ -34,6 +34,12 @@ def plot(data_list, test_names, graph_dir):
         percentages = (((((data_grouped_by_model > 0) * 1).mean()) * 100).to_frame()).T
         models_using_rule = ((data_grouped_by_model > 0) * 1).agg('sum').to_frame().T
 
+        data_grouped_by_model.rename(utility.rename_test_name_for_paper_presentation(test_names), axis='columns', inplace=True)
+        percentages.rename(utility.rename_test_name_for_paper_presentation(test_names), axis='columns',
+                                     inplace=True)
+        models_using_rule.rename(utility.rename_test_name_for_paper_presentation(test_names), axis='columns',
+                                     inplace=True)
+
         # Remove the 'Rule' part of e.g 'Rule A'
         for df in [rules_summed, percentages, models_using_rule]:
             df.rename(columns=lambda x: re.sub('rule', '', x), inplace=True)

--- a/graph_utility/total_reductions.py
+++ b/graph_utility/total_reductions.py
@@ -39,14 +39,13 @@ def plot(data_list, test_names, graph_dir):
 
     # Rename indices to be test names, instead of int index
     points_df = utility.rename_index_to_test_name(points_df, test_names)
-
     # data_to_plot = utility.split_into_all_with_without(points_df)
     # png_names = ['all', 'with', 'without']
-
+    points_df.rename(utility.rename_test_name_for_paper_presentation(test_names), axis='rows', inplace=True)
     if len(points_df) != 0 and len(points_df.columns) != 0:
         # Plot the plot
         sns.set_theme(style="darkgrid", palette="pastel")
-        plot = data.plot(kind='barh', width=0.75, linewidth=2, figsize=(10, 10))
+        plot = points_df.plot(kind='barh', width=0.75, linewidth=2, figsize=(10, 10))
 
         plt.legend(bbox_to_anchor=(1.02, 1), loc='best', borderaxespad=0)
         plt.xscale('log')

--- a/graph_utility/utility.py
+++ b/graph_utility/utility.py
@@ -135,7 +135,7 @@ def get_reduced_size(row):
         pre_size = get_pre_size(row)
         post_size = get_post_size(row)
         return ((post_size / pre_size) * 100) if post_size > 0 and ((post_size / pre_size) * 100) < 100 and (
-                    (post_size / pre_size) * 100) > 0 else np.nan
+                (post_size / pre_size) * 100) > 0 else np.nan
     else:
         return np.nan
 
@@ -240,18 +240,27 @@ def remove_errors_datalist(data_list):
         data.drop(data[data['answer'] == 'ERR'].index, inplace=True)
     return data_list
 
+
 def rename_test_name_for_paper_presentation(test_names):
     new_test_names = {}
     for test_name in test_names:
         if "fixed" in test_name:
             new_test_name = test_name.replace('fixed', '')
-        else:
-            new_test_name = test_name.replace('with-', 'base.')
+        elif "with" in test_name:
+            splits = test_name.split('-')
 
-        new_test_name = f"({new_test_name})⃰"
+            if len(splits) > 0:
+                rules = ""
+                split_rules = list(splits)[1]
+                for i, split in enumerate(split_rules):
+                    rules += f"{split}⃰"
+                    if i < len(split_rules) - 1:
+                        rules += "."
+            new_test_name = f"(base.{rules})⃰"
 
         new_test_names[test_name] = new_test_name
     return new_test_names
+
 
 '''
 def split_into_all_with_without(df):

--- a/graph_utility/utility.py
+++ b/graph_utility/utility.py
@@ -245,7 +245,7 @@ def rename_test_name_for_paper_presentation(test_names):
     new_test_names = {}
     for test_name in test_names:
         if "fixed" in test_name:
-            new_test_name = test_name.replace('fixed', '')
+            new_test_name = f"(base)⃰"
         elif "base" in test_name:
             new_test_name = f"(TAPAAL)⃰"
         else:

--- a/graph_utility/utility.py
+++ b/graph_utility/utility.py
@@ -267,7 +267,7 @@ def rename_test_name_for_paper_presentation(test_names):
                                 rules += "."
 
             if "with" in test_name:
-                new_test_name = f"(base⃰.{rules})⃰"
+                new_test_name = f"(base.{rules})⃰"
             else:
                 new_test_name = f"({rules})⃰"
 

--- a/graph_utility/utility.py
+++ b/graph_utility/utility.py
@@ -240,6 +240,18 @@ def remove_errors_datalist(data_list):
         data.drop(data[data['answer'] == 'ERR'].index, inplace=True)
     return data_list
 
+def rename_test_name_for_paper_presentation(test_names):
+    new_test_names = {}
+    for test_name in test_names:
+        if "fixed" in test_name:
+            new_test_name = test_name.replace('fixed', '')
+        else:
+            new_test_name = test_name.replace('with-', 'base.')
+
+        new_test_name = f"({new_test_name})⃰"
+
+        new_test_names[test_name] = new_test_name
+    return new_test_names
 
 '''
 def split_into_all_with_without(df):

--- a/graph_utility/utility.py
+++ b/graph_utility/utility.py
@@ -245,7 +245,7 @@ def rename_test_name_for_paper_presentation(test_names):
     new_test_names = {}
     for test_name in test_names:
         if "fixed" in test_name:
-            new_test_name = f"(base)⃰"
+            new_test_name = f"base⃰"
         elif "base" in test_name:
             new_test_name = f"(TAPAAL)⃰"
         else:
@@ -267,7 +267,7 @@ def rename_test_name_for_paper_presentation(test_names):
                                 rules += "."
 
             if "with" in test_name:
-                new_test_name = f"(base.{rules})⃰"
+                new_test_name = f"(base⃰.{rules})⃰"
             else:
                 new_test_name = f"({rules})⃰"
 

--- a/graph_utility/utility.py
+++ b/graph_utility/utility.py
@@ -246,17 +246,30 @@ def rename_test_name_for_paper_presentation(test_names):
     for test_name in test_names:
         if "fixed" in test_name:
             new_test_name = test_name.replace('fixed', '')
-        elif "with" in test_name:
+        elif "base" in test_name:
+            new_test_name = f"(TAPAAL)⃰"
+        else:
             splits = test_name.split('-')
 
             if len(splits) > 0:
                 rules = ""
                 split_rules = list(splits)[1]
                 for i, split in enumerate(split_rules):
-                    rules += f"{split}⃰"
-                    if i < len(split_rules) - 1:
-                        rules += "."
-            new_test_name = f"(base.{rules})⃰"
+                    if split.isalpha():
+                        rules += f"{split}⃰"
+
+                        if i < len(split_rules) - 1:
+                            any_next_rules = False
+                            for split1 in split_rules[i + 1:]:
+                                if split1.isalpha():
+                                    any_next_rules = True
+                            if any_next_rules:
+                                rules += "."
+
+            if "with" in test_name:
+                new_test_name = f"(base.{rules})⃰"
+            else:
+                new_test_name = f"({rules})⃰"
 
         new_test_names[test_name] = new_test_name
     return new_test_names


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/33687173/148640905-7de6b4f6-4e26-41af-9b9a-5e9336f858a5.png)


Restricts time sensitive line plots to only tests above 5 seconds.
Remove title from lineplots, as we will use the caption in the paper to describe the graph
rename x-axis to queries
rename tests to reflect the regex name scheme Jiri suggested
`fixed-base` renamed to just `base`
if another `base` experiment is present, I assume this is the old base (i.e TAPAAL from before we started working on it), and this will be named `TAPAAL`
Can also handle names with `only`, e.g `only-RA` will become `(R*.A*)*`
